### PR TITLE
v1.2.1: Add mandatory `open()` method, report version

### DIFF
--- a/examples/server-lowdb.js
+++ b/examples/server-lowdb.js
@@ -21,7 +21,9 @@ const db = new HFDB({
   })
 })
 
-new DataServer({
+const ds = new DataServer({
   port: 8899,
   db,
 })
+
+ds.open()

--- a/examples/server-sql.js
+++ b/examples/server-sql.js
@@ -21,7 +21,9 @@ const db = new HFDB({
   })
 })
 
-new DataServer({
+const ds = new DataServer({
   port: 8899,
   db,
 })
+
+ds.open()

--- a/lib/cmds/get_candles.js
+++ b/lib/cmds/get_candles.js
@@ -82,8 +82,8 @@ module.exports = async (ds, ws, msg) => {
   })
 
   debug(
-    'responding with %d candles for range %d - %d',
-    candles.length, reqStart, reqEnd
+    'responding with %d candles for range %d - %d [%s %s]',
+    candles.length, reqStart, reqEnd, symbol, tf
   )
   
   send(ws, ['data.candles', exchange, symbol, tf, type, reqStart, reqEnd, meta, candles])

--- a/lib/server.js
+++ b/lib/server.js
@@ -75,18 +75,32 @@ module.exports = class DataServer {
       url: restURL,
     })
 
+    this.port = port
+    this.wss = null
+  }
+
+  open () {
+    if (this._wss) {
+      throw new Error('already open')
+    }
+
     this.wss = new WS.Server({
       clientTracking: true,
-      port
+      port: this.port
     })
 
     this.wss.on('connection', this.onWSConnected.bind(this))
 
-    debug('websocket API open on port %d', port)
+    debug('websocket API open on port %d', this.port)
   }
 
   close () {
+    if (!this.wss) {
+      throw new Error('already closed')
+    }
+
     this.wss.close()
+    this.wss = null
 
     Object.values(this.bfxProxies).forEach(proxy => proxy.close())
     this.bfxProxies = {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-data-server",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "HF data server module",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
* adds `open()` to the HF DS to avoid constructor side effects
* reports version on initial connection packet
* bump to 1.2.1