### PR TITLE
Fix: Sync Key Parsing & Reporting (1.3.3)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.3.3
+- fix: sync key parsing and reporting
+
 # 1.3.2
 - bump knex to version v0.19.5 for security fix
 

--- a/lib/cmds/get_candles.js
+++ b/lib/cmds/get_candles.js
@@ -20,6 +20,10 @@ module.exports = async (ds, ws, msg) => {
     let syncRequired = true
     let futureSync = ds.futureSyncFor(optimizedRange)
 
+    // Notify even if sync is later redundant; we notify end even if redundant
+    ds.notifySyncStart({ exchange, symbol, tf, start, end })
+    send(ws, ['data.sync.start', exchange, symbol, tf, start, end, meta])
+
     while (futureSync) {
       debug(
         'waiting for future sync to complete (%d - %d)',
@@ -53,9 +57,6 @@ module.exports = async (ds, ws, msg) => {
         await ds.expectSync({ start, end })
         debug('sync %d - %d finished, proceeding', start, end)
       } else {
-        ds.notifySyncStart({ exchange, symbol, tf, start, end })
-        send(ws, ['data.sync.start', exchange, symbol, tf, start, end, meta])
-
         await Candle.syncRange({
           exchange,
           symbol,
@@ -63,13 +64,12 @@ module.exports = async (ds, ws, msg) => {
         }, {
           start,
           end
-        }, () => {}, () => {
-          ds.notifySyncEnd({ exchange, symbol, tf, start, end })
         })
-
-        send(ws, ['data.sync.end', exchange, symbol, tf, start, end, meta])
       }
     }
+
+    ds.notifySyncEnd({ exchange, symbol, tf, start, end })
+    send(ws, ['data.sync.end', exchange, symbol, tf, start, end, meta])
   }
 
   const candles = await Candle.getInRange([

--- a/lib/cmds/get_candles.js
+++ b/lib/cmds/get_candles.js
@@ -4,7 +4,7 @@ const debug = require('debug')('bfx:hf:data-server:cmds:get-candles')
 const send = require('../wss/send')
 
 module.exports = async (ds, ws, msg) => {
-  const [, exchange, symbol, tf, type, reqStart, reqEnd, meta] = msg
+  const [, exchange, symbol, tf, type, start, end, meta] = msg
   const { db } = ds
   const { Candle } = db
 
@@ -12,8 +12,8 @@ module.exports = async (ds, ws, msg) => {
     exchange,
     symbol,
     tf,
-    start: reqStart,
-    end: reqEnd
+    start,
+    end
   })
 
   if (optimizedRange) { // null if no sync required
@@ -37,8 +37,8 @@ module.exports = async (ds, ws, msg) => {
         exchange,
         symbol,
         tf,
-        start: reqStart,
-        end: reqEnd
+        start,
+        end
       })
 
       if (!optimizedRange) {
@@ -78,8 +78,8 @@ module.exports = async (ds, ws, msg) => {
     ['tf', '=', tf]
   ], {
     key: 'mts',
-    start: reqStart,
-    end: reqEnd
+    start,
+    end
   }, {
     orderBy: 'mts',
     orderDirection: 'asc'
@@ -87,10 +87,10 @@ module.exports = async (ds, ws, msg) => {
 
   debug(
     'responding with %d candles for range %d - %d [%s %s]',
-    candles.length, reqStart, reqEnd, symbol, tf
+    candles.length, start, end, symbol, tf
   )
 
-  send(ws, ['data.candles', exchange, symbol, tf, type, reqStart, reqEnd, meta, candles])
+  send(ws, ['data.candles', exchange, symbol, tf, type, start, end, meta, candles])
 
   return candles
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -123,14 +123,18 @@ class DataServer {
   }
 
   /**
-   * Returns an array of active sync ranges, in the format { start, end }
+   * Returns an array of active sync ranges
    *
    * @return {Object[]} ranges
    */
   getRunningSyncRanges () {
     return Object.keys(this.activeSyncs).map(k => {
-      const [start, end] = k.split('-')
+      const [exchange, symbol, tf, start, end] = k.split('-')
+
       return {
+        exchange,
+        symbol,
+        tf,
         start: +start,
         end: +end
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-data-server",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "HF data server module",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
### Description:
Fixes active sync key parsing, and switches to reporting sync start/end even if no sync occurs for a given candle request. This prevents future identical requests from triggering the sync logic if they arrive while the previous sync is pending/being calculated

### Fixes:
- [x] `activeSyncs` key parsing now correctly includes all metadata
- [x] sync reporting

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
