### PR TITLE
exec.bt: add meta field for requestId

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.4.0
+- feature: adds meta field to exec.bt command
+
 # 1.3.5
 - meta: bump bitfinex-api-node to v4
 

--- a/docs/ws_api.md
+++ b/docs/ws_api.md
@@ -13,10 +13,10 @@ After opening a websocket connection to a running `bfx-hf-data-server` instance,
 #### `exec.bt` response packets
 * `['data.sync.start', exchange, symbol, timeFrame, from, to, meta]` - when a sync process starts
 * `['data.sync.end', exchange, symbol, timeFrame, from, to, meta]` - when a sync process end
-* `['bt.start', null, null, from, to, null, nTrades, nCandles]` - before the backtest data stream
-* `['bt.end', null, null, from, to]` - after the backtest data stream
-* `['bt.candle', null, null, candle]` - individual BT candle
-* `['bt.trade', null, trade]` - individual BT trade
+* `['bt.start', null, null, from, to, null, nTrades, nCandles, meta]` - before the backtest data stream
+* `['bt.end', null, null, from, to, meta]` - after the backtest data stream
+* `['bt.candle', null, null, candle, meta]` - individual BT candle
+* `['bt.trade', null, trade, meta]` - individual BT trade
 
 #### `get.bts` response packets
 * `['data.bts', bts]`

--- a/lib/cmds/exec_bt.js
+++ b/lib/cmds/exec_bt.js
@@ -20,7 +20,7 @@ module.exports = async (ds, ws, msg) => {
   const { Candle, Trade } = db
   const btArgs = parseExecMsg(msg)
   const {
-    exchange, sync, symbol, tf, includeTrades, includeCandles, start, end
+    exchange, sync, symbol, tf, includeTrades, includeCandles, start, end, meta
   } = btArgs
 
   if (sync) {
@@ -51,15 +51,15 @@ module.exports = async (ds, ws, msg) => {
   let sentTrades = 0
   let sentCandles = 0
 
-  send(ws, ['bt.start', '', '', start, end,, 0, candleData.length]) // eslint-disable-line
+  send(ws, ['bt.start', '', '', start, end,, 0, candleData.length, meta]) // eslint-disable-line
 
   if (!includeTrades) {
     candleData.forEach((c) => {
-      send(ws, ['bt.candle', '', '', c])
+      send(ws, ['bt.candle', '', '', c, meta])
       sentCandles += 1
     })
 
-    send(ws, ['bt.end', '', '', start, end])
+    send(ws, ['bt.end', '', '', start, end, meta])
     debug('stream complete [%d candles]', sentCandles)
     return // NOTE: hard return
   }
@@ -90,16 +90,16 @@ module.exports = async (ds, ws, msg) => {
         (candleI < candleData.length) &&
         (candleData[candleI].mts < trade.mts)
       ) {
-        send(ws, ['bt.candle', '', '', candleData[candleI]])
+        send(ws, ['bt.candle', '', '', candleData[candleI], meta])
         candleI++
         sentCandles++
       }
     }
 
-    send(ws, ['bt.trade', '', trade])
+    send(ws, ['bt.trade', '', trade, meta])
     sentTrades++
   }
 
-  send(ws, ['bt.end', '', '', start, end])
+  send(ws, ['bt.end', '', '', start, end, meta])
   debug('stream complete [%d candles, %d trades]', sentCandles, sentTrades)
 }

--- a/lib/util/parse_exec_msg.js
+++ b/lib/util/parse_exec_msg.js
@@ -2,10 +2,10 @@
 
 module.exports = (msg = []) => {
   const [
-    exchange, start, end, symbol, tf, includeCandles, includeTrades, sync = true
+    exchange, start, end, symbol, tf, includeCandles, includeTrades, sync = true, meta
   ] = msg[1] || []
 
   return {
-    exchange, start, end, symbol, tf, includeCandles, includeTrades, sync
+    exchange, start, end, symbol, tf, includeCandles, includeTrades, sync, meta
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-data-server",
-  "version": "1.3.5",
+  "version": "1.4.0",
   "description": "HF data server module",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
### Description:
Adds meta field to the `exec.bt` command, similar to `getCandles`.

### Breaking changes:
None

### New features:
- [x] additional `meta` field added to `exec.bt`

### Fixes:
None

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [x] Documentation updated
