### PR TITLE
backtest: allow trades/candles as different sources

### DIFF
--- a/lib/cmds/exec_strategy.js
+++ b/lib/cmds/exec_strategy.js
@@ -64,35 +64,40 @@ module.exports = async (ds, ws, msg) => {
     symbol, tf, rangeString(start, end)
   )
 
-  const candleData = await Candle.getInRange([
-    ['exchange', '=', exchange],
-    ['symbol', '=', symbol],
-    ['tf', '=', tf]
-  ], {
-    key: 'mts',
-    start,
-    end
-  }, {
-    orderBy: 'mts',
-    orderDirection: 'asc'
-  })
+  let candleData = []
+  if (includeCandles) {
+    candleData = await Candle.getInRange([
+      ['exchange', '=', exchange],
+      ['symbol', '=', symbol],
+      ['tf', '=', tf]
+    ], {
+      key: 'mts',
+      start,
+      end
+    }, {
+      orderBy: 'mts',
+      orderDirection: 'asc'
+    })
 
-  debug('loaded %d candles', candleData.length)
+    debug('loaded %d candles', candleData.length)
+  }
 
-  const tradeData = await Trade.getInRange([
-    ['exchange', '=', exchange],
-    ['symbol', '=', symbol]
-  ], {
-    key: 'mts',
-    start,
-    end
-  }, {
-    orderBy: 'mts',
-    orderDirection: 'asc'
-  })
+  let tradeData = []
+  if (includeTrades) {
+    tradeData = await Trade.getInRange([
+      ['exchange', '=', exchange],
+      ['symbol', '=', symbol]
+    ], {
+      key: 'mts',
+      start,
+      end
+    }, {
+      orderBy: 'mts',
+      orderDirection: 'asc'
+    })
 
-  tradeData.sort((a, b) => a.mts - b.mts)
-  debug('loaded %d trades', tradeData.length)
+    debug('loaded %d trades', tradeData.length)
+  }
 
   execOffline(strategy, {
     candles: candleData,


### PR DESCRIPTION
with https://github.com/bitfinexcom/bfx-hf-ui/pull/219 the values
vor `includeCandles` and `includeTrades` are not hardcoded to
`true` any more.

this PR takes the settings into account for serverside backtesting

 - no test added because it would need a network connection