### PR TITLE
defineIndicators should be optional

### DIFF
--- a/lib/cmds/exec_strategy.js
+++ b/lib/cmds/exec_strategy.js
@@ -55,13 +55,15 @@ module.exports = async (ds, ws, msg) => {
   const perfManager = new PerformanceManager(priceFeed, { allocation: capitalAllocation })
 
   try {
+    const indicators = strategy.defineIndicators
+      ? strategy.defineIndicators(Indicators)
+      : {}
+
     strategy = HFS.define({
       ...strategy,
       tf: timeframe,
       symbol,
-      indicators: {
-        ...strategy.defineIndicators(Indicators)
-      },
+      indicators,
       priceFeed,
       perfManager
     })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-data-server",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "HF data server module",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Otherwise, this will break strategies that don't have code definition for `defineIndicators`